### PR TITLE
feat: add http response compression

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from search.search import SearchError, stream_to_base64_url
 import frontmatter
 import markdown
 from markdown.extensions.toc import TocExtension
+from flask_compress import Compress
 
 
 logger = logging.getLogger(__name__)
@@ -23,6 +24,7 @@ app = Flask(
     static_folder="static"
 )
 app.secret_key = "myverysecretkey"
+Compress(app)
 
 
 @app.route('/')

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ openpyxl==3.1.2
 pandas==2.2.2
 python-frontmatter==1.1.0
 gunicorn==21.2.0
+flask-compress==1.15


### PR DESCRIPTION
This PR closes #13 

It will:
- Add flask-compress as a requirement
- Use flask compress to support compressed http responses

## To test:
- Go to: http://127.0.0.1:5000/search
- Make a large search: Use a larger selection from `batchlist.txt`
[batchlist.txt](https://github.com/NBISweden/vector-oligo-search/files/15236242/batchlist.txt)
- Verify that the responses are compressed using your favorite method
  - One way is by checking the network tab in your firefox dev-tools.
